### PR TITLE
fix 2 bugs of batch (#284)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         "gym>=0.15.4",
         "tqdm",
-        "numpy!=1.16.0",  # https://github.com/numpy/numpy/issues/12793
+        "numpy!=1.16.0,<1.20.0",  # https://github.com/numpy/numpy/issues/12793
         "tensorboard",
         "torch>=1.4.0",
         "numba>=0.51.0",

--- a/test/base/test_buffer.py
+++ b/test/base/test_buffer.py
@@ -621,9 +621,9 @@ def test_multibuf_hdf5():
             'done': i % 3 == 2,
             'info': {"number": {"n": i, "t": info_t}, 'extra': None},
         }
-        buffers["vector"].add(**Batch.cat([[kwargs], [kwargs], [kwargs]]),
+        buffers["vector"].add(**Batch.stack([kwargs, kwargs, kwargs]),
                               buffer_ids=[0, 1, 2])
-        buffers["cached"].add(**Batch.cat([[kwargs], [kwargs], [kwargs]]),
+        buffers["cached"].add(**Batch.stack([kwargs, kwargs, kwargs]),
                               cached_buffer_ids=[0, 1, 2])
 
     # save
@@ -657,7 +657,7 @@ def test_multibuf_hdf5():
             'done': False,
             'info': {"number": {"n": i}, 'Timelimit.truncate': True},
         }
-        buffers[k].add(**Batch.cat([[kwargs], [kwargs], [kwargs], [kwargs]]))
+        buffers[k].add(**Batch.stack([kwargs, kwargs, kwargs, kwargs]))
         act = np.zeros(buffers[k].maxsize)
         if k == "vector":
             act[np.arange(5)] = np.array([0, 1, 2, 3, 5])

--- a/tianshou/data/buffer.py
+++ b/tianshou/data/buffer.py
@@ -174,7 +174,7 @@ class ReplayBuffer:
                 )
         try:
             value[self._index] = inst
-        except KeyError:  # inst is a dict/Batch
+        except ValueError:  # inst is a dict/Batch
             for key in set(inst.keys()).difference(value.keys()):
                 self._buffer_allocator([name, key], inst[key])
             self._meta[name][self._index] = inst


### PR DESCRIPTION
1. `_create_value(Batch(a={}, b=[1, 2, 3]), 10, False)`

before:
```python
TypeError: cannot concatenate with Batch() which is scalar
```
after:
```python
Batch(
    a: Batch(),
    b: array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
)
```

2. creating keys in a batch's subkey, e.g. 
```python
a = Batch(info={"key1": [0, 1], "key2": [2, 3]})
a[0] = Batch(info={"key1": 2, "key3": 4})
print(a)
```
before:
```python
Batch(
    info: Batch(
              key1: array([0, 1]),
              key2: array([0, 3]),
          ),
)
```
after:
```python
ValueError: Creating keys is not supported by item assignment.
```

3. small optimization for `Batch.stack_` and `Batch.cat_`, raise ValueError when receiving invalid data format.

- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [ ] I have visited the [source website](https://github.com/thu-ml/tianshou)
- [ ] I have searched through the [issue tracker](https://github.com/thu-ml/tianshou/issues) for duplicates
- [ ] I have mentioned version numbers, operating system and environment, where applicable:
  ```python
  import tianshou, torch, sys
  print(tianshou.__version__, torch.__version__, sys.version, sys.platform)
  ```
